### PR TITLE
feat: make focus key configurable in settings

### DIFF
--- a/src/core/keyboard/KeyboardListener.ts
+++ b/src/core/keyboard/KeyboardListener.ts
@@ -132,8 +132,9 @@ export class KeyboardListener {
 			return triggerResult;
 		}
 
-		// Handle focus mode key ("i")
-		if (hotkeyMode && event.key === "i") {
+		// Handle focus mode key (configurable; skipped if unset)
+		const focusKey = this.plugin.settings.focusKey;
+		if (hotkeyMode && focusKey && event.key === focusKey) {
 			return {
 				shouldProcess: true,
 				action: "focus",

--- a/src/shortcutsSettingTab.ts
+++ b/src/shortcutsSettingTab.ts
@@ -58,6 +58,7 @@ export const DEFAULT_KEY_SEQUENCE_SETTINGS: KeySequenceSettings = {
 	editorScopeEnabled: true,
 	editorScopeTrigger: "Alt-s s",
 	editorScopeShowBorder: true,
+	focusKey: "i",
 	firstLoaded: true,
 };
 
@@ -202,6 +203,26 @@ export class ShortcutsSettingTab extends PluginSettingTab {
 						this.captureShortcutModeTrigger(hotkeyContainer);
 					}),
 			);
+
+		new Setting(containerEl)
+			.setName("Focus key")
+			.setDesc(
+				'While in shortcut mode, pressing this key restores focus to the editor (inspired by Vim\'s "i" for insert mode). ' +
+				'Leave blank to disable — useful if you want to use "i" in shortcut sequences and already have another way to exit shortcut mode (e.g. Esc).',
+			)
+			.addText((text) => {
+				text
+					.setPlaceholder("i")
+					.setValue(this.plugin.settings.focusKey ?? "")
+					.onChange((value) => {
+						const key = value.slice(-1);
+						text.setValue(key);
+						this.plugin.settings.focusKey = key;
+						this.plugin.saveSettings();
+					});
+				text.inputEl.maxLength = 1;
+				text.inputEl.style.width = "3em";
+			});
 
 		new Setting(containerEl)
 			.setName("Show key press visualizer")

--- a/src/types/settings.d.ts
+++ b/src/types/settings.d.ts
@@ -15,5 +15,8 @@ interface KeySequenceSettings {
 	editorScopeTrigger: string;
 	editorScopeShowBorder: boolean;
 
+	/** Key used to restore editor focus while in shortcut mode (default: "i", leave empty to disable) */
+	focusKey: string;
+
 	firstLoaded: boolean;
 }


### PR DESCRIPTION
## Summary

- Adds a `focusKey` setting (default `"i"`) to `KeySequenceSettings` and `DEFAULT_KEY_SEQUENCE_SETTINGS`
- Adds a **Focus key** settings UI block in the General settings panel with a 1-character text input
- Updates `KeyboardListener.handleKeyDown` to read `focusKey` from settings instead of hardcoding `"i"`

## Why

Users who assign `"i"` to a shortcut sequence (or prefer Esc to exit shortcut mode) were blocked because the focus-restore key was hardcoded. Leaving the field blank now disables the behavior entirely.

## Test plan
- [ ] Default behavior unchanged: pressing `i` in shortcut mode still restores editor focus
- [ ] Setting the field to another character makes that key restore focus instead
- [ ] Clearing the field disables the focus key — `i` passes through to shortcut sequences normally
- [ ] Build passes with no TypeScript errors