### PR TITLE
fix(settings): fix hotkey capture ignoring keypresses in settings panel

### DIFF
--- a/CHANGLOG.md
+++ b/CHANGLOG.md
@@ -1,3 +1,15 @@
+## 0.4.0-beta.2
+
+### Bug Fixes
+
+- **settings**: Fix hotkey capture ignoring keypresses in the settings panel
+  - Pressing keys while "Press hotkey..." was active would focus a nearby button
+    instead of recording the key, because Obsidian's settings modal intercepted
+    keyboard events before the document-level capture handler could run
+  - Fix: inject a hidden `<input>` element and focus it for the duration of
+    capture; the browser routes all keyboard input to the focused input, bypassing
+    modal-level navigation handlers
+
 ## 0.4.0-beta.1
 
 ### Features

--- a/src/shortcutsSettingTab.ts
+++ b/src/shortcutsSettingTab.ts
@@ -758,12 +758,20 @@ export class ShortcutsSettingTab extends PluginSettingTab {
 
 		this.plugin.capturing = true;
 
+		// A focused <input> reliably owns keyboard events — Obsidian's settings
+		// modal won't intercept them for UI navigation the way it does for
+		// non-input elements. We hide it visually but keep it reachable.
+		const hiddenInput = element.createEl("input", {
+			type: "text",
+			attr: { style: "position:absolute;opacity:0;width:1px;height:1px;pointer-events:none;" },
+		});
+
 		const pressedModifiers = new Set<number>();
 
 		const handleKeyDown = (e: KeyboardEvent) => {
 			if (!this.isCapturing) return;
 			e.preventDefault();
-			e.stopPropagation();
+			e.stopImmediatePropagation();
 
 			const keyCode = e.keyCode;
 			const now = Date.now();
@@ -815,16 +823,15 @@ export class ShortcutsSettingTab extends PluginSettingTab {
 		};
 
 		this.innerComponent = new Component();
-		this.innerComponent.registerDomEvent(
-			document,
-			"keydown",
-			handleKeyDown,
-		);
-		this.innerComponent.registerDomEvent(document, "keyup", handleKeyUp);
+		this.innerComponent.registerDomEvent(hiddenInput, "keydown", handleKeyDown);
+		this.innerComponent.registerDomEvent(hiddenInput, "keyup", handleKeyUp);
 
 		this.innerComponent.register(() => {
 			this.isCapturing = false;
+			hiddenInput.remove();
 		});
+
+		hiddenInput.focus();
 	}
 
 	finishCapture(


### PR DESCRIPTION
## Summary

- Pressing any key while **"Press hotkey..."** was active would focus a nearby button instead of recording the shortcut key
- Root cause: Obsidian's settings modal registers its own keyboard handler earlier than the plugin's document-level capture handler, so modal navigation wins and the keypress is never recorded
- Fix: at capture start, inject a hidden `<input>` element inside the active span and immediately focus it; the browser routes all keyboard input to a focused `<input>`, bypassing the modal's navigation handlers; the input is removed when capture ends

## Test plan

- [ ] Click **+** to add a hotkey — "Press hotkey..." appears
- [ ] Press a letter key (e.g. `[`, `g`, `a`) — it should be recorded, not focus a button
- [ ] Press Space and Enter — they should be recorded, not activate the confirm/add button
- [ ] Press a modifier combo (e.g. `Cmd+K`) — recorded correctly
- [ ] Click the ✓ confirm button — capture ends cleanly, input element is removed from DOM
- [ ] Click ✕ or navigate away — capture cancelled cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)