### PR TITLE
fix(settings): remove scissors icons from community plugins nav label

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -331,15 +331,6 @@ Press \`x\` to continue to the Shortcuts plugin settings page where you can conf
 						(tab.navEl as HTMLElement).dataset.pluginId =
 							"shortcuts";
 
-						tab.navEl.createEl(
-							"span",
-							{
-								cls: "shortcuts-logo",
-							},
-							(el) => {
-								setIcon(el, "scissors");
-							},
-						);
 					}
 					const result = next.call(this);
 					return result;


### PR DESCRIPTION
## Summary

- The plugin patches `setting.onOpen` to inject a `<span>` with a scissors icon into its own nav item in the community plugins list
- This adds visual clutter inconsistent with every other plugin in the list
- Fix: remove the `createEl` call that appends the icon span to `tab.navEl`

## Test plan

- [ ] Open Settings → Community plugins — "Shortcuts" label has no scissors icons
- [ ] All other plugin settings functionality is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)