### PR TITLE
fix(settings): fix multi-key sequence capture stopping after first key

### DIFF
--- a/src/shortcutsSettingTab.ts
+++ b/src/shortcutsSettingTab.ts
@@ -780,11 +780,12 @@ export class ShortcutsSettingTab extends PluginSettingTab {
 		this.plugin.capturing = true;
 
 		// A focused <input> reliably owns keyboard events — Obsidian's settings
-		// modal won't intercept them for UI navigation the way it does for
-		// non-input elements. We hide it visually but keep it reachable.
-		const hiddenInput = element.createEl("input", {
+		// modal won't intercept them for UI navigation. Attached to containerEl
+		// (inside the modal) so the modal's focus trap doesn't eject it, but
+		// outside activeSpan so that setText() on the span doesn't destroy it.
+		const hiddenInput = this.containerEl.createEl("input", {
 			type: "text",
-			attr: { style: "position:absolute;opacity:0;width:1px;height:1px;pointer-events:none;" },
+			attr: { style: "position:fixed;opacity:0;width:1px;height:1px;pointer-events:none;top:0;left:0;" },
 		});
 
 		const pressedModifiers = new Set<number>();


### PR DESCRIPTION
## Summary

- After the hidden-input fix for hotkey capture, multi-key sequences (e.g. `C then N`) stopped working — only the first key was recorded
- **Root cause**: the hidden `<input>` was a child of `activeSpan`. When the first key was captured, `updateDisplay()` called `activeSpan.setText()`, which wiped all child elements including the input, causing focus loss
- Moving the input to `document.body` triggered the modal's focus trap, which ejected focus back to the `+` button
- **Fix**: append the hidden input to `this.containerEl` — inside the modal (satisfying the focus trap) but outside `activeSpan` (safe from `setText()`)

## Test plan

- [ ] Click `+` to add a hotkey — "Press hotkey..." appears
- [ ] Press a single key — recorded correctly
- [ ] Press a sequence (e.g. `C` then `N`) — both keys recorded as `C then N`
- [ ] Press a modifier combo (e.g. `Cmd+K`) — recorded correctly
- [ ] Confirm and cancel both clean up the hidden input from the DOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)